### PR TITLE
#163356402 Refactor double worded response fields to camelCase

### DIFF
--- a/server/controllers/helpers/RecordTransformer.js
+++ b/server/controllers/helpers/RecordTransformer.js
@@ -1,0 +1,65 @@
+/**
+ * @class RecordTransformer
+ * @description Takes a list of objects and transforms the objects based on an
+ * action'
+ */
+class RecordTransformer {
+  /**
+   * @func transform
+   * @param {Array} records
+   * @param {String} field
+   * @param {String} action
+   * @returns {Array} Array with its items transformed
+   */
+  static transform(records, field, action) {
+    switch (action) {
+      case 'remove-nulls': {
+        const newRecords = records.map((record) => {
+          if (record[field] === null) {
+            delete record[field];
+          }
+
+          return record;
+        });
+
+        return newRecords;
+      }
+
+      case 'nulls-to-empty-array': {
+        const newRecords = records.map((record) => {
+          if (record[field] === null) {
+            record[field] = [];
+          }
+
+          return record;
+        });
+
+        return newRecords;
+      }
+
+      case 'inner-nulls-with-empty-string': {
+        const newRecords = records.map((record) => {
+          const values = record[field].map((value) => {
+            if (value === null) {
+              value = '';
+            }
+
+            return value;
+          });
+
+          record[field] = values;
+
+          return record;
+        });
+
+        return newRecords;
+      }
+
+      default: {
+        return records;
+      }
+    }
+  }
+}
+
+export default RecordTransformer;

--- a/server/controllers/helpers/index.js
+++ b/server/controllers/helpers/index.js
@@ -2,7 +2,60 @@ export const sendResponse = ({ res, status, payload }) => res
   .status(status)
   .send(payload);
 
+/* eslint-disable */
+class RecordTransformer {
+  static transform(records, field, action) {
+    switch (action) {
+      case 'remove-nulls': {
+        const newRecords = records.map((record) => {
+          if (record[field] === null) {
+            delete record[field];
+          }
+
+          return record;
+        });
+
+        return newRecords;
+      }
+
+      case 'nulls-to-empty-array': {
+        const newRecords = records.map((record) => {
+          if (record[field] === null) {
+            record[field] = [];
+          }
+
+          return record;
+        })
+
+        return newRecords;
+      }
+
+      case 'inner-nulls-with-empty-string': {
+        const newRecords = records.map((record) => {
+          const values = record[field].map(value => {
+            if (value === null) {
+              value = '';
+            }
+
+            return value;
+          });
+
+          record[field] = values;
+
+          return record;
+        });
+
+        return newRecords;
+      }
+
+      default: {
+        return records;
+      }
+    }
+  }
+}
 
 export default {
-  sendResponse
+  sendResponse,
+  RecordTransformer
 };

--- a/server/controllers/helpers/index.js
+++ b/server/controllers/helpers/index.js
@@ -2,60 +2,6 @@ export const sendResponse = ({ res, status, payload }) => res
   .status(status)
   .send(payload);
 
-/* eslint-disable */
-class RecordTransformer {
-  static transform(records, field, action) {
-    switch (action) {
-      case 'remove-nulls': {
-        const newRecords = records.map((record) => {
-          if (record[field] === null) {
-            delete record[field];
-          }
-
-          return record;
-        });
-
-        return newRecords;
-      }
-
-      case 'nulls-to-empty-array': {
-        const newRecords = records.map((record) => {
-          if (record[field] === null) {
-            record[field] = [];
-          }
-
-          return record;
-        })
-
-        return newRecords;
-      }
-
-      case 'inner-nulls-with-empty-string': {
-        const newRecords = records.map((record) => {
-          const values = record[field].map(value => {
-            if (value === null) {
-              value = '';
-            }
-
-            return value;
-          });
-
-          record[field] = values;
-
-          return record;
-        });
-
-        return newRecords;
-      }
-
-      default: {
-        return records;
-      }
-    }
-  }
-}
-
 export default {
-  sendResponse,
-  RecordTransformer
+  sendResponse
 };

--- a/server/controllers/meetup.js
+++ b/server/controllers/meetup.js
@@ -4,6 +4,21 @@ import { search } from './helpers/search';
 import { sendResponse } from './helpers';
 import { arrayHasValues, objectHasProps, uniq } from '../utils';
 
+// transforms meetup records
+const transformMeetups = meetups => meetups.map((meetup) => {
+  meetup.tags = meetup.tags === null ? [] : meetup.tags;
+
+  const tags = meetup.tags.map((tag) => {
+    if (tag === null) {
+      tag = '';
+    }
+    return tag;
+  });
+
+  meetup.tags = tags;
+  return meetup;
+});
+
 export default {
   async getAllMeetups(req, res) {
     try {
@@ -11,7 +26,7 @@ export default {
         const { searchTerm } = req.query;
 
         const meetups = await db.queryDb({
-          text: 'SELECT * FROM Meetup'
+          text: 'SELECT id, topic, location, happeningon as "happeningOn", tags FROM Meetup'
         });
 
         const meetupRecords = meetups.rows;
@@ -22,7 +37,9 @@ export default {
 
         const allMeetups = [...byTopic, ...byLocation, ...byTag];
 
-        const filteredMeetups = _.uniqBy(allMeetups, 'id');
+        let filteredMeetups = _.uniqBy(allMeetups, 'id');
+
+        filteredMeetups = transformMeetups(filteredMeetups);
 
         if (allMeetups.length) {
           return sendResponse({

--- a/server/test/unit/helpers/index.spec.js
+++ b/server/test/unit/helpers/index.spec.js
@@ -1,0 +1,77 @@
+import 'chai/register-should';
+import Helpers from '../../../controllers/helpers';
+
+const { RecordTransformer } = Helpers;
+
+describe.only('RecordTransformer', () => {
+  const testRecords = [
+    {
+      id: 1, name: 'my name', likes: null, dislikes: ['something', null, null]
+    },
+    {
+      id: 2, name: 'my name', likes: null, dislikes: ['something', null, null]
+    },
+    {
+      id: 3, name: 'my name', likes: null, dislikes: ['something']
+    },
+  ];
+
+  before(() => {
+
+  });
+
+  describe('class', () => {
+    it('should be a function', () => {
+      RecordTransformer.should.be.a('Function');
+    });
+
+    it('should have a "transform" static method', () => {
+      RecordTransformer.transform.should.be.a('function');
+    });
+  });
+
+  describe('tranform()', () => {
+    it('should remove nulls from records', () => {
+      const records = [...testRecords];
+      const newRecords = RecordTransformer.transform(records, 'likes', 'remove-nulls');
+
+      newRecords[0].should.not.have.property('likes');
+    });
+
+    it('should replace nulls with empty array', () => {
+      const records = [
+        { title: 'hello', things: null },
+        { title: 'hi', things: null },
+      ];
+
+      const newRecords = RecordTransformer.transform(records, 'things', 'nulls-to-empty-array');
+
+      Array.isArray(newRecords[0].things).should.be.true;
+      newRecords[0].things.length.should.equal(0);
+    });
+
+    it('should replace inner nulls with empty string', () => {
+      const records = [
+        { title: 'hello', things: [null, 'something'] },
+        { title: 'hi', things: [null] },
+      ];
+
+      const newRecords = RecordTransformer.transform(records, 'things', 'inner-nulls-with-empty-string');
+
+      newRecords[0].things[0].should.be.a('string');
+      newRecords[0].things[0].length.should.equal(0);
+    });
+
+    it('should return the original array if an invalid or no action was specified', () => {
+      const records = [
+        { title: 'hello', things: [null, 'something'] },
+        { title: 'hi', things: [null] },
+      ];
+
+      const newRecords = RecordTransformer.transform(records, 'things', '');
+
+      newRecords[0].things.length.should.equal(2);
+      newRecords[0].things.should.include(null);
+    });
+  });
+});

--- a/server/test/unit/helpers/index.spec.js
+++ b/server/test/unit/helpers/index.spec.js
@@ -1,7 +1,5 @@
 import 'chai/register-should';
-import Helpers from '../../../controllers/helpers';
-
-const { RecordTransformer } = Helpers;
+import RecordTransformer from '../../../controllers/helpers/RecordTransformer';
 
 describe.only('RecordTransformer', () => {
   const testRecords = [
@@ -15,10 +13,6 @@ describe.only('RecordTransformer', () => {
       id: 3, name: 'my name', likes: null, dislikes: ['something']
     },
   ];
-
-  before(() => {
-
-  });
 
   describe('class', () => {
     it('should be a function', () => {


### PR DESCRIPTION
#### What does this PR do?
Refactors response fields that are double worded to camelCase to aid readability
#### Description of Task to be completed?
Change every double worded response from database (lowercased by postgres by default) for e.g `happeningon` to `happeningOn`.
#### How should this be manually tested?
- Clone repo
- `npm install`
-  Refer to the docs to add the required db configuration parameters
- Add these configuration parameters as environment variables
- `npm run dev:start`
- Open Postman, and try creating a meetup - Refer to the docs to see instructions on required fields
- You should see that double-worded response fields have been camelCased
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#163356402
#### Screenshots (if appropriate)
#### Questions: