### PR TITLE
#164001031 Enhance Maximum Meetup Tags Restriction

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -583,7 +583,14 @@ You can add tags to meetups using this action
 
         {
             "status": 422,
-            "error": "You cannot add tags to this meetup, because the meetup does not exist"
+            "error": "Maximum tags a meetup can have is 5"
+        }
+
++ Response 404 (application/json)
+
+        {
+            "status": 404,
+            "error": "The requested meetup does not exist"
         }
 
 ### Fetch All Meetup Tags [GET]

--- a/server/controllers/meetup.js
+++ b/server/controllers/meetup.js
@@ -281,6 +281,17 @@ export default {
           });
         }
 
+        if (meetupRecord.tags.length >= MAX_TAGS_PER_MEETUP) {
+          return sendResponse({
+            res,
+            status: 422,
+            payload: {
+              status: 422,
+              error: 'Maximum tags a meetup can have is 5'
+            }
+          });
+        }
+
         const newTags = meetupRecord.tags.concat(tags);
 
         const uniqueTags = uniq(newTags);
@@ -309,7 +320,7 @@ export default {
         status: 404,
         payload: {
           status: 404,
-          error: 'You cannot add tags to this meetup, because the meetup does not exist'
+          error: 'The requested meetup does not exist'
         }
       });
     } catch (e) {


### PR DESCRIPTION
#### What does this PR do?
It enhances the maximum tags restriction that a meetup can have
#### Description of Task to be completed?
Admin should not be able to add more than 5 tags to a meetup
#### How should this be manually tested?
- Clone repo
- Install deps: `npm install`
- Add env variables as specified in `env-sample` file
- Run server: `npm run dev:start`
- Sign In as An Admin -> Use the temporal email/password for admins: admin1@admin.com and password: admin1234
- Using Postman, make a POST request to add tags /api/v1/meetups/1/tags with a list of tags greater than 5
- You should receive a 422 response error
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
#164001031
#### Screenshots (if appropriate)
#### Questions: