### PR TITLE
#164267665 Fix Create RSVP bug

### DIFF
--- a/server/controllers/meetup-question.js
+++ b/server/controllers/meetup-question.js
@@ -128,8 +128,8 @@ export default {
   async getMeetupQuestions(req, res) {
     try {
       const result = await db.queryDb({
-        text: `SELECT * FROM Question WHERE meetup=$1
-               ORDER BY votes DESC`,
+        text: `SELECT id, title, body, createdOn as "createdOn", createdby as "user", meetup, votes FROM Question 
+        WHERE meetup=$1ORDER BY votes DESC`,
         values: [req.params.meetupId]
       });
 

--- a/server/controllers/rsvp.js
+++ b/server/controllers/rsvp.js
@@ -38,7 +38,12 @@ export default {
       const { userId } = req.decodedToken;
 
       if (meetup) {
-        const rsvps = await Rsvp.find({ where: { '"user"': userId } });
+        const rsvps = await Rsvp.find({
+          where: {
+            '"user"': userId,
+            meetup: meetupId
+          }
+        });
 
         if (rsvps.length) {
           return sendResponse({

--- a/server/models/all/Question.js
+++ b/server/models/all/Question.js
@@ -52,7 +52,7 @@ class Question extends Model {
    */
   async findAndSortByVotes() {
     const questionsResult = await this._db.queryDb({
-      text: 'SELECT id, title, body, meetup, votes, createdby as "createdBy", createdon as "createdOn" FROM Question ORDER BY votes DESC'
+      text: 'SELECT id, title, body, meetup, votes, createdby as user, createdon as "createdOn" FROM Question ORDER BY votes DESC'
     });
 
     return questionsResult.rows;


### PR DESCRIPTION
#### What does this PR do?
- Fixes Create RSVP bug
#### Description of Task to be completed?
When a User makes an RSVP for a meetup, it doesn't hit the server, but only shows the feedback. Rsvp-ing for a meetup should both show feedback for successful RSVPing and also hit the server
#### How should this be manually tested?
- Clone repo
- Install deps: `npm install`
- Add DB specific env variables. Follow the README doc for more info
- Start server: `npm run dev:start`
- In the request URL bar on Postman: Create an account or sign in if you have one already
- Make a request to http://localhost:9999/api/v1/meetups/{meetup_id}/rsvps
  - meetup_id is the ID of the meetup
- You should have no problems rsvp-ing for any meetup
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
#164267665
#### Screenshots (if appropriate)
#### Questions: